### PR TITLE
Suppress gcc warning.

### DIFF
--- a/include/cdm_Array.h
+++ b/include/cdm_Array.h
@@ -146,7 +146,7 @@ public:
   }
 
   /// データタイプ文字列の取得
-  char* getDataTypeString() const
+  const char* getDataTypeString() const
   {
     switch( m_dtype )
     {


### PR DESCRIPTION
cdm_Array.h:154:14: warning: conversion from string literal to 'char *' is deprecated [-Wdeprecated-writable-strings]
      return "INT8";