### PR TITLE
Suppress gcc warning

### DIFF
--- a/include/cdm_Array.h
+++ b/include/cdm_Array.h
@@ -191,7 +191,7 @@ public:
   }
 
   /// 配列形状文字列の取得
-  char* getArrayShapeString() const
+  const char* getArrayShapeString() const
   {
     switch(m_shape)
     {


### PR DESCRIPTION
Add `const` to suppress gcc warning: deprecated conversion from string constant to ‘char*’