### PR TITLE
Remove AC_CHECK_HEADER_STDBOOL 

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -232,7 +232,6 @@ AC_CHECK_HEADERS([stdlib.h unistd.h])
 #
 # Checks for typedefs, structures, and compiler characteristics.
 #
-AC_HEADER_STDBOOL
 AC_C_INLINE
 AC_TYPE_SIZE_T
 


### PR DESCRIPTION
since C99 code is not used in this library.