### PR TITLE
Fix Intel MPI compiler build. <mpi.h> must be included at first.

### DIFF
--- a/tools/netcdf2dfi/src/main.C
+++ b/tools/netcdf2dfi/src/main.C
@@ -14,6 +14,12 @@
  * @author aics
  */
 
+#ifdef _CDM_WITHOUT_MPI_
+ #include "mpi_stubs.h"
+#else
+ #include "mpi.h"
+#endif
+
 #include "netcdf2dfi.h"
 
 /** @brief netcdf2dfiメイン関数

--- a/tools/upacs2dfi/src/fub_DATA.C
+++ b/tools/upacs2dfi/src/fub_DATA.C
@@ -5,6 +5,12 @@
  *
  */
 
+#ifdef _CDM_WITHOUT_MPI_
+ #include "mpi_stubs.h"
+#else
+ #include "mpi.h"
+#endif
+
 #include "fub_DATA.h"
 
 // #################################################################


### PR DESCRIPTION
`mpi.h` must be included before stdio.h, otherwise we'll have the following error:

```
error: #error directive: "SEEK_SET is #defined but must not be for the C++ binding of MPI. Include mpi.h before stdio.h"
  #error "SEEK_SET is #defined but must not be for the C++ binding of MPI. Include mpi.h before stdio.h"
```

This is a workaround of compiling CDMlib with netcdf support using `./configure` 